### PR TITLE
Derive more auto-derivable traits

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -6,7 +6,7 @@ use std::error;
 
 /// An XML parser errors.
 #[allow(missing_docs)]
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub enum Error {
     InvalidDeclaration(StreamError, TextPos),
     InvalidComment(StreamError, TextPos),
@@ -84,7 +84,7 @@ impl error::Error for Error {
 
 
 /// A stream parser errors.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub enum StreamError {
     /// The steam ended earlier than we expected.
     ///
@@ -210,7 +210,7 @@ impl error::Error for StreamError {
 /// Position in text.
 ///
 /// Position indicates a row/line and a column in the original text. Starting from 1:1.
-#[derive(Clone, Copy, PartialEq, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 #[allow(missing_docs)]
 pub struct TextPos {
     pub row: u32,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,7 @@ pub use crate::xmlchar::*;
 
 /// An XML token.
 #[allow(missing_docs)]
-#[derive(Clone, Copy, PartialEq, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub enum Token<'a> {
     /// Declaration token.
     ///
@@ -266,7 +266,7 @@ pub enum Token<'a> {
 
 
 /// `ElementEnd` token.
-#[derive(Clone, Copy, PartialEq, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub enum ElementEnd<'a> {
     /// Indicates `>`
     Open,
@@ -279,7 +279,7 @@ pub enum ElementEnd<'a> {
 
 /// Representation of the [ExternalID](https://www.w3.org/TR/xml/#NT-ExternalID) value.
 #[allow(missing_docs)]
-#[derive(Clone, Copy, PartialEq, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub enum ExternalId<'a> {
     System(StrSpan<'a>),
     Public(StrSpan<'a>, StrSpan<'a>),
@@ -288,7 +288,7 @@ pub enum ExternalId<'a> {
 
 /// Representation of the [EntityDef](https://www.w3.org/TR/xml/#NT-EntityDef) value.
 #[allow(missing_docs)]
-#[derive(Clone, Copy, PartialEq, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub enum EntityDefinition<'a> {
     EntityValue(StrSpan<'a>),
     ExternalId(ExternalId<'a>),

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -15,7 +15,7 @@ type Result<T> = ::core::result::Result<T, StreamError>;
 
 
 /// Representation of the [Reference](https://www.w3.org/TR/xml/#NT-Reference) value.
-#[derive(Clone, Copy, PartialEq, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub enum Reference<'a> {
     /// An entity reference.
     ///
@@ -30,7 +30,7 @@ pub enum Reference<'a> {
 
 
 /// A streaming XML parsing interface.
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub struct Stream<'a> {
     pos: usize,
     end: usize,

--- a/src/strspan.rs
+++ b/src/strspan.rs
@@ -7,7 +7,7 @@ use core::ops::{Deref, Range};
 /// Like `&str`, but also contains the position in the input XML,
 /// from which it was parsed.
 #[must_use]
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub struct StrSpan<'a> {
     text: &'a str,
     start: usize,


### PR DESCRIPTION
Hello,
I'm an active user of this crate and noticed, that some types of this crate don't have `[Partial]Eq` implemented, despite it being possible. I searched the code base and derived some more traits.

As this is only a simple addition, there shouln't be any fallout. Tests are passing locally.