### PR TITLE
Character Conformance Changes

### DIFF
--- a/src/xmlchar.rs
+++ b/src/xmlchar.rs
@@ -73,14 +73,12 @@ impl XmlCharExt for char {
 
     #[inline]
     fn is_xml_char(&self) -> bool {
+        if (*self as u32) < 0x20 {
+            return (*self as u8).is_xml_space()
+        }
         match *self as u32 {
-              0x000009
-            | 0x00000A
-            | 0x00000D
-            | 0x000020...0x00D7FF
-            | 0x00E000...0x00FFFD
-            | 0x010000...0x10FFFF => true,
-            _ => false,
+              0xFFFF | 0xFFFE => false,
+            _ => true,
         }
     }
 }

--- a/src/xmlchar.rs
+++ b/src/xmlchar.rs
@@ -10,6 +10,10 @@ pub trait XmlCharExt {
 
     /// Checks if the value is within the
     /// [Char](https://www.w3.org/TR/xml/#NT-Char) range.
+    /// 
+    /// Does not check for surrogate code points U+D800-
+    /// U+DFFF, since that check was performed by rust
+    /// when the str was constructed.
     fn is_xml_char(&self) -> bool;
 }
 


### PR DESCRIPTION
There is no need to check for Unicode surrogate code points since a Rust char is [excluded from ever containing one](https://doc.rust-lang.org/std/primitive.char.html)... 

The only bytes left not allowed are everything under 0x20 that is not \t \r or \n, also non-characters 0xFFFE & 0xFFFF. This gives a speed bump (consistent 10% with a 13 MB xml file on my machine), bc the character-by-character-check gets much simpler.